### PR TITLE
Add share/copy settlement results

### DIFF
--- a/PokerSettle/ViewModels/SettlementViewModel.swift
+++ b/PokerSettle/ViewModels/SettlementViewModel.swift
@@ -67,4 +67,19 @@ class SettlementViewModel {
     var totalToPay: Double {
         settlements.reduce(0) { $0 + $1.amount }
     }
+
+    var shareText: String {
+        var lines: [String] = []
+        lines.append("Game: \(game.displayName)")
+        lines.append("Total Pot: \(game.totalPot.asCurrency())")
+        if settlements.isEmpty {
+            lines.append("\nAll players broke even!")
+        } else {
+            lines.append("\nSettlements:")
+            for s in settlements {
+                lines.append("\(s.fromPlayerName) pays \(s.toPlayerName) \(s.amount.asCurrency())")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
 }

--- a/PokerSettle/Views/GameList/GameDetailView.swift
+++ b/PokerSettle/Views/GameList/GameDetailView.swift
@@ -86,6 +86,13 @@ struct GameDetailView: View {
         }
         .navigationTitle(game.displayName)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                ShareLink(item: shareText) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                }
+            }
+        }
     }
 
     private func reactivateGame() {
@@ -100,6 +107,21 @@ struct GameDetailView: View {
 
         try? modelContext.save()
         dismiss()
+    }
+
+    private var shareText: String {
+        var lines: [String] = []
+        lines.append("Game: \(game.displayName)")
+        lines.append("Total Pot: \(game.totalPot.asCurrency())")
+        if game.settlements.isEmpty {
+            lines.append("\nAll players broke even!")
+        } else {
+            lines.append("\nSettlements:")
+            for s in game.settlements {
+                lines.append("\(s.fromPlayerName) pays \(s.toPlayerName) \(s.amount.asCurrency())")
+            }
+        }
+        return lines.joined(separator: "\n")
     }
 
     private var formattedDate: String {

--- a/PokerSettle/Views/Settlement/SettlementView.swift
+++ b/PokerSettle/Views/Settlement/SettlementView.swift
@@ -83,6 +83,12 @@ struct SettlementView: View {
                         dismiss()
                     }
                 }
+                ToolbarItem(placement: .topBarTrailing) {
+                    ShareLink(item: viewModel.shareText) {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                    .disabled(!viewModel.validationResult.isValid)
+                }
             }
             .alert("Error", isPresented: $viewModel.showError) {
                 Button("OK") { }

--- a/PokerSettleTests/PokerSettleTests.swift
+++ b/PokerSettleTests/PokerSettleTests.swift
@@ -295,6 +295,76 @@ struct PokerSettleTests {
         #expect(game.totalChips == 0)
     }
 
+    // MARK: - SettlementViewModel.shareText Tests
+
+    @Test("shareText includes game name and total pot")
+    func testShareTextIncludesGameInfo() throws {
+        let game = Game(name: "Friday Night Poker", buyInAmount: 10.0, chipCount: 100)
+
+        let alice = PlayerSession(playerName: "Alice", buyInCount: 1, finalChipCount: 150)
+        alice.game = game
+        let bob = PlayerSession(playerName: "Bob", buyInCount: 1, finalChipCount: 50)
+        bob.game = game
+        game.players = [alice, bob]
+
+        let viewModel = SettlementViewModel(game: game)
+        let text = viewModel.shareText
+
+        #expect(text.contains("Friday Night Poker"))
+        #expect(text.contains(game.totalPot.asCurrency()))
+    }
+
+    @Test("shareText formats settlement rows as 'X pays Y amount'")
+    func testShareTextFormatsSettlements() throws {
+        let game = Game(buyInAmount: 10.0, chipCount: 100)
+
+        let alice = PlayerSession(playerName: "Alice", buyInCount: 1, finalChipCount: 150)
+        alice.game = game
+        let bob = PlayerSession(playerName: "Bob", buyInCount: 1, finalChipCount: 50)
+        bob.game = game
+        game.players = [alice, bob]
+
+        let viewModel = SettlementViewModel(game: game)
+        let text = viewModel.shareText
+
+        #expect(text.contains("Bob pays Alice"))
+        #expect(text.contains(5.0.asCurrency()))
+    }
+
+    @Test("shareText with all players breaking even shows no payment lines")
+    func testShareTextBreakEven() throws {
+        let game = Game(buyInAmount: 10.0, chipCount: 100)
+
+        let alice = PlayerSession(playerName: "Alice", buyInCount: 1, finalChipCount: 100)
+        alice.game = game
+        let bob = PlayerSession(playerName: "Bob", buyInCount: 1, finalChipCount: 100)
+        bob.game = game
+        game.players = [alice, bob]
+
+        let viewModel = SettlementViewModel(game: game)
+        let text = viewModel.shareText
+
+        #expect(text.contains("broke even"))
+        #expect(!text.contains("pays"))
+    }
+
+    @Test("shareText uses displayName for unnamed game")
+    func testShareTextUsesDisplayName() throws {
+        let game = Game(buyInAmount: 10.0, chipCount: 100)
+
+        let alice = PlayerSession(playerName: "Alice", buyInCount: 1, finalChipCount: 100)
+        alice.game = game
+        let bob = PlayerSession(playerName: "Bob", buyInCount: 1, finalChipCount: 100)
+        bob.game = game
+        game.players = [alice, bob]
+
+        let viewModel = SettlementViewModel(game: game)
+        let text = viewModel.shareText
+
+        #expect(text.hasPrefix("Game: "))
+        #expect(text.contains(game.displayName))
+    }
+
     // MARK: - PlayerSession Model Tests
 
     @Test("Player total buy-in calculation")


### PR DESCRIPTION
Closes #3

## Summary
- Adds a `shareText` computed property to `SettlementViewModel` that formats the game name, total pot, and each payment as plain text (e.g. `Bob pays Alice $5.00`)
- Adds a share button (↑ icon) to the **Settle Up** screen toolbar — disabled if the chip count is invalid
- Adds a share button to the **Game Detail** view toolbar for completed games
- Tapping opens the native iOS share sheet (iMessage, WhatsApp, copy to clipboard, etc.)

## Tests
Added 4 new unit tests for `shareText`:
- Includes game name and total pot
- Formats settlement rows correctly (`X pays Y $amount`)
- Shows "broke even" message when no settlements needed
- Uses `displayName` for unnamed games

All 21 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)